### PR TITLE
Feat: Support using external EIPs

### DIFF
--- a/modules/terraform-aws-alternat/main.tf
+++ b/modules/terraform-aws-alternat/main.tf
@@ -41,8 +41,8 @@ locals {
 
   endpoints = merge(local.ec2_endpoint, local.lambda_endpoint)
 
-  reuse_nat_instance_eips = try(length(var.nat_instance_eip_ids), 0) > 0
-  nat_instance_eip_ids    = local.reuse_nat_instance_eips ? var.nat_instance_eip_ids : try(aws_eip.nat_instance_eips[*].id, [])
+  reuse_nat_instance_eips = try(length(var.nat_instance_eip_ids), 0) > 0 && var.nat_instance_eip_ids == length(var.vpc_public_subnet_ids)
+  nat_instance_eip_ids    = local.reuse_nat_instance_eips ? var.nat_instance_eip_ids : aws_eip.nat_instance_eips[*].id
 }
 
 resource "aws_eip" "nat_instance_eips" {

--- a/modules/terraform-aws-alternat/main.tf
+++ b/modules/terraform-aws-alternat/main.tf
@@ -41,7 +41,7 @@ locals {
 
   endpoints = merge(local.ec2_endpoint, local.lambda_endpoint)
 
-  reuse_nat_instance_eips = try(length(var.nat_instance_eip_ids), 0) > 0 && var.nat_instance_eip_ids == length(var.vpc_public_subnet_ids)
+  reuse_nat_instance_eips = try(length(var.nat_instance_eip_ids), 0) > 0 && length(var.nat_instance_eip_ids) == length(var.vpc_public_subnet_ids)
   nat_instance_eip_ids    = local.reuse_nat_instance_eips ? var.nat_instance_eip_ids : aws_eip.nat_instance_eips[*].id
 }
 

--- a/modules/terraform-aws-alternat/main.tf
+++ b/modules/terraform-aws-alternat/main.tf
@@ -41,7 +41,7 @@ locals {
 
   endpoints = merge(local.ec2_endpoint, local.lambda_endpoint)
 
-  reuse_nat_instance_eips = try(length(var.nat_instance_eip_ids), 0) > 0 && length(var.nat_instance_eip_ids) == length(var.vpc_public_subnet_ids)
+  reuse_nat_instance_eips = length(var.nat_instance_eip_ids) == length(var.vpc_public_subnet_ids) # var.nat_instance_eip_ids ignored if doesn't match subnet count
   nat_instance_eip_ids    = local.reuse_nat_instance_eips ? var.nat_instance_eip_ids : aws_eip.nat_instance_eips[*].id
 }
 

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -63,6 +63,7 @@ variable "alternat_image_uri" {
 variable "ingress_security_group_ids" {
   description = "A list of security group IDs that are allowed by the NAT instance."
   type        = list(string)
+  default     = []
 }
 
 variable "max_instance_lifetime" {
@@ -117,6 +118,12 @@ variable "nat_instance_type" {
   description = "Instance type to use for NAT instances."
   type        = string
   default     = "c6gn.8xlarge"
+}
+
+variable "nat_instance_eip_ids" {
+  description = "Allocation IDs of Elastic IPs to associate with the NAT instances. If not specified, EIPs will be created."
+  type        = list(string)
+  default     = []
 }
 
 variable "subnet_suffix" {

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -121,7 +121,11 @@ variable "nat_instance_type" {
 }
 
 variable "nat_instance_eip_ids" {
-  description = "Allocation IDs of Elastic IPs to associate with the NAT instances. If not specified, EIPs will be created."
+  description = <<-EOT
+  Allocation IDs of Elastic IPs to associate with the NAT instances. If not specified, EIPs will be created.
+
+  Note: if the number of EIPs does not match the number of subnets specified in `vpc_public_subnet_ids`, this variable will be ignored.
+  EOT
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## What

* Support using external EIPs instead of only creating new EIPs
* Misc: add default value for `ingress_security_group_ids` (should be empty by default)

## Why 

* Use case: user has pool of EIPs (allowlisted by some third party, for example) and wants to use them

## Notes

* `aws_eip.nat_instance_eips[*].id` is the same as `aws_eip.nat_instance_eips[*].allocation_id`