### PR TITLE
Fixes the image to link to chime.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 NAT Gateways are dead. Long live NAT instances!
 
-Built and released with 💚 by <img src="/assets/Chime_company_logo.png" alt="Chime Engineering" width="146"/>
+Built and released with 💚 by <a href="https://chime.com"><img src="/assets/Chime_company_logo.png" alt="Chime Engineering" width="146"/></a>
 
 [![GitHub Actions](https://github.com/1debit/alternat/workflows/Build/badge.svg)](https://github.com/1debit/alternat/actions)
 


### PR DESCRIPTION
Accidentally merged in #36 without the `href`.
