### PR TITLE
Refactor for compatibility with other IaC tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ We would like this benefit to benefit as many users as possible. Possible future
 
 ## Contributing
 
-[Issues](https://github.com/issues) and [pull requests](https://github.com/1debit/alternat/pulls) are most welcome!
+[Issues](https://github.com/1debit/alternat/issues) and [pull requests](https://github.com/1debit/alternat/pulls) are most welcome!
 
 alterNAT is intended to be a safe, welcoming space for collaboration. Contributors are expected to adhere to the [Contributor Covenant code of conduct](CODE_OF_CONDUCT.md).
 

--- a/docs/0.2.0-migration-guide.md
+++ b/docs/0.2.0-migration-guide.md
@@ -1,0 +1,88 @@
+## Migration guide for v0.2.0
+
+The v0.2.0 release changes the Terraform module inputs in order to associate a route table with a set of private and public subnets and an availability zone. Follow the steps below to migrate to this version. The migration can be completed without interrupting or terminating the NAT instances.
+
+The modules accept a new input called `var.vpc_az_maps`, a list of objects mapping route tables to their corresponding subnets and AZs:
+
+```
+variable "vpc_az_maps" {
+  description = "A map of az to private route tables that the NAT instances will manage."
+  type = list(object({
+    az                 = string
+    private_subnet_ids = list(string)
+    public_subnet_id   = string
+    route_table_ids    = list(string)
+  }))
+}
+```
+
+Previouly, using the alternat module with the open source [`terraform-aws-vpc` module](https://github.com/terraform-aws-modules/terraform-aws-vpc) looked something like this:
+
+```
+module "alternat" {
+  source = "git@github.com:1debit/alternat.git//modules/terraform-aws-alternat?ref=v0.1.3"
+
+  alternat_image_uri         = "012345678901.dkr.ecr.us-west-2.amazonaws.com/alternat"
+  alternat_image_tag         = "v0.1.3"
+  ingress_security_group_ids = [aws_security_group.client_sg.id]
+  private_route_table_ids    = module.vpc.private_route_table_ids
+  vpc_private_subnet_ids     = module.vpc.private_subnets
+  vpc_public_subnet_ids      = module.vpc.public_subnets
+  vpc_id                      = module.vpc.vpc_id
+}
+```
+
+With `vpc_az_maps`, the module call now looks like:
+
+```
+data "aws_subnet" "subnet" {
+  count = length(module.vpc.private_subnets)
+  id    = module.vpc.private_subnets[count.index]
+}
+
+locals {
+  vpc_az_maps = [
+    for index, rt in module.vpc.private_route_table_ids
+    : {
+      az                 = data.aws_subnet.subnet[index].availability_zone
+      route_table_ids    = [rt]
+      public_subnet_id   = module.vpc.public_subnets[index]
+      private_subnet_ids = [module.vpc.private_subnets[index]]
+    }
+  ]
+}
+
+module "alternat" {
+  source = "git@github.com:1debit/alternat.git//modules/terraform-aws-alternat?ref=v0.2.0"
+
+  alternat_image_uri         = "188238883601.dkr.ecr.us-west-2.amazonaws.com/alternat"
+  alternat_image_tag         = "v0.2.0"
+  ingress_security_group_ids = [aws_security_group.client_sg.id]
+  vpc_az_maps                 = local.vpc_az_maps
+  vpc_id                      = module.vpc.vpc_id
+}
+```
+
+In the code above, the `az` value is optional. You could also simply use the `index` if you prefer.
+
+If you do use the `aws_subnet` data source to pull the availability zone (as shown above), note that the VPC and its subnets must exist before the `alternat` module is called. Otherwise you will receive an `Invalid for_each argument` error because "Terraform cannot predict how many instances will be created."
+
+After making the above changes, running `terraform plan` will show some resources as changed and others as replaced. You can avoid the important replacements by using `moved` blocks. For example, in the `us-west-2` region:
+
+
+```
+moved {
+  from = module.alternat_instances.aws_nat_gateway.main[0]
+  to   = module.alternat_instances.aws_nat_gateway.main["us-west-2a"]
+}
+moved {
+  from = module.alternat_instances.aws_eip.nat_gateway_eips[0]
+  to   = module.alternat_instances.aws_eip.nat_gateway_eips["us-west-2a"]
+}
+moved {
+  from = module.alternat_instances.aws_autoscaling_group.nat_instance[0]
+  to   = module.alternat_instances.aws_autoscaling_group.nat_instance["us-west-2a"]
+}
+```
+
+You'll need to repeat the above blocks for each availability zone. The Lambda functions and CloudWatch event targets will still be replaced, but this will not cause any downtime for the NAT instances or NAT gateways.

--- a/docs/0.2.0-migration-guide.md
+++ b/docs/0.2.0-migration-guide.md
@@ -63,12 +63,9 @@ module "alternat" {
 }
 ```
 
-In the code above, the `az` value is optional. You could also simply use the `index` if you prefer.
-
-If you do use the `aws_subnet` data source to pull the availability zone (as shown above), note that the VPC and its subnets must exist before the `alternat` module is called. Otherwise you will receive an `Invalid for_each argument` error because "Terraform cannot predict how many instances will be created."
+In the code above, the `availability_zone` of the `aws_subnet` data source will not resolve until the VPC is created. Therefore, for new deployments where the VPC and alterNAT are being set up for the first time, an error will occur stating, `Invalid for_each argument` error because "Terraform cannot predict how many instances will be created." To work around this, follow the advice in the error message by using the `-target` argument to first create the VPC. Users with existing VPCs/subnets are not impacted by this.
 
 After making the above changes, running `terraform plan` will show some resources as changed and others as replaced. You can avoid the important replacements by using `moved` blocks. For example, in the `us-west-2` region:
-
 
 ```
 moved {

--- a/functions/replace-route/app.py
+++ b/functions/replace-route/app.py
@@ -14,16 +14,12 @@ logger.setLevel(logging.INFO)
 logging.getLogger('boto3').setLevel(logging.CRITICAL)
 logging.getLogger('botocore').setLevel(logging.CRITICAL)
 
+
 ec2_client = boto3.client("ec2")
 
 LIFECYCLE_KEY = "LifecycleHookName"
 ASG_KEY = "AutoScalingGroupName"
 EC2_KEY = "EC2InstanceId"
-
-# Subnet naming convention must be <OPTIONAL PREFIX>-<SUBNET_SUFFIX>-<AZ>
-# Configurable via SUBNET_SUFFIX env var
-# e.g. my-vpc-name-private-us-east-1a
-DEFAULT_SUBNET_SUFFIX = "private"
 
 # Checks every CONNECTIVITY_CHECK_INTERVAL seconds, exits after 1 minute
 DEFAULT_CONNECTIVITY_CHECK_INTERVAL = "5"
@@ -57,189 +53,16 @@ def get_az_and_vpc_zone_identifier(auto_scaling_group):
     raise MissingVPCZoneIdentifierError(asg_objects)
 
 
-def get_vpc_and_subnet_id(subnet_suffix, asg_az, vpc_zone_identifier):
+def get_vpc_id(route_table):
     try:
-        subnets = ec2_client.describe_subnets(SubnetIds=[vpc_zone_identifier])
-
+        route_tables = ec2_client.describe_route_tables(RouteTableIds=[route_table])
     except botocore.exceptions.ClientError as error:
-        logger.error("Unable to get vpc and subnet id")
+        logger.error("Unable to get vpc id")
         raise error
-
-    logger.debug("Subnets: %s", subnets)
-
-    if subnets["Subnets"] and len(subnets["Subnets"]) > 0:
-        logger.debug("Number of subnets: %s", len(subnets["Subnets"]))
-
-        subnet = subnets["Subnets"][0]
-        public_subnet_id = subnet["SubnetId"]
-        logger.debug("Public subnet ID: %s", public_subnet_id)
-
-        vpc_id = subnet["VpcId"]
+    if "RouteTables" in route_tables and len(route_tables["RouteTables"]) == 1:
+        vpc_id = route_tables["RouteTables"][0]["VpcId"]
         logger.debug("VPC ID: %s", vpc_id)
-    else:
-        raise MissingVPCandSubnetError(subnets)
-
-    try:
-        az_subnets = ec2_client.describe_subnets(
-            Filters = [
-                {
-                    "Name": "availability-zone",
-                    "Values": [
-                        asg_az
-                    ]
-                },
-                {
-                    "Name": "vpc-id",
-                    "Values": [
-                        vpc_id
-                    ]
-                },
-            ]
-        )
-    except botocore.exceptions.ClientError as error:
-        logger.error("Unable to describe subnets")
-        raise error
-
-    if len(az_subnets.get("Subnets")) < 1:
-        logger.error("Unable to find subnets associated with AZ! Cannot replace route.")
-        raise MissingAZSubnetError(az_subnets)
-
-    private_subnet_id = ""
-    for subnet in az_subnets.get("Subnets"):
-        tags = subnet.get("Tags")
-        for tag in tags:
-            if tag.get("Key") == "Name":
-                subnet_name = tag.get("Value")
-                if f"{subnet_suffix}-{asg_az}" in subnet_name:
-                    private_subnet_id = subnet.get("SubnetId")
-                    break
-
-    if private_subnet_id == "":
-        logger.error("Unable to find the private subnet ID for %s! Cannot replace route.", asg_az)
-        raise MissingAZSubnetError(az_subnets)
-
-    logger.debug("Private subnet ID: %s", private_subnet_id)
-    return vpc_id, private_subnet_id, public_subnet_id
-
-
-def get_vpc_and_subnets_from_lambda(function_name):
-    """
-    This function operates as follows:
-    - Get the Lambda function currently being executed
-    - Read the VPC config of the function
-    - Find the VPC and subnet IDs of the function
-    - Use the VPC and subnet ID to deduce which AZ the function runs in
-    - Use the VPC ID and AZ to deduce which corresponding public subnet the NAT Gateway is in
-    - Return the VPC ID, private subnet ID of the Lambda, and public subnet ID of the NAT
-    Gateway for use in replacing the route.
-    """
-    boto_lambda = boto3.client("lambda")
-    try:
-        func = boto_lambda.get_function(FunctionName=function_name)
-    except botocore.exceptions.ClientError as error:
-        logger.error("Unable to get Lambda function")
-        raise error
-
-    logger.info(func)
-    vpc_config = func.get("Configuration").get("VpcConfig")
-    if vpc_config == "":
-        logger.error("Unable to read VpcConfig from function")
-        raise MissingVpcConfigError(func.get("Configuration"))
-
-    subnet_ids = vpc_config.get("SubnetIds")
-    if len(subnet_ids) != 1:
-        logger.error("Unable to find single subnet ID for this function! Cannot replace route.")
-        raise MissingFunctionSubnetError(vpc_config)
-    subnet_id = subnet_ids[0]
-
-    try:
-        # Due to a limitation in how moto returns Lambda Vpc configuration, we cannot
-        # get vpc_id from the get_function() response above.
-        # See https://github.com/spulec/moto/blob/59910c812e3008506a5b8d7841d88e8bf4e4e153/moto/awslambda/models.py#L484
-        # Instead, make a second call to describe_subnets and filter on the subnet-id which is reliable.
-        vpc_id = ec2_client.describe_subnets(Filters=[
-            {
-                "Name": "subnet-id",
-                "Values": [
-                    subnet_id
-                ]
-            }
-        ]).get("Subnets")[0]["VpcId"]
-        if vpc_id == "":
-            logger.error("Could not discover VpcId from Lambda subnet")
-            raise MissingVpcConfigError(vpc_config)
-
-        lambda_subnet = ec2_client.describe_subnets(
-            Filters=[
-                {
-                    "Name": "subnet-id",
-                    "Values": [
-                        subnet_id
-                    ]
-                },
-                {
-                    "Name": "vpc-id",
-                    "Values": [
-                        vpc_id
-                    ]
-                },
-            ]
-        )
-    except botocore.exceptions.ClientError as error:
-        logger.error("Unable to describe subnets")
-        raise error
-
-    lambda_subnets = lambda_subnet.get("Subnets")
-    if len(lambda_subnets) != 1:
-        logger.error("Unable to describe Lambda subnet ID! Cannot replace route.")
-        raise MissingAZSubnetError(lambda_subnet)
-    if "AvailabilityZone" not in lambda_subnets[0]:
-        logger.error("Unable to find AZ of lambda function subnet! Cannot replace route.")
-        raise MissingAZSubnetError(lambda_subnets)
-    availability_zone = lambda_subnets[0]["AvailabilityZone"]
-    lambda_subnet_id = lambda_subnets[0].get("SubnetId")
-
-    try:
-        az_subnets = ec2_client.describe_subnets(
-            Filters=[
-                {
-                    "Name": "availability-zone",
-                    "Values": [
-                        availability_zone
-                    ]
-                },
-                {
-                    "Name": "vpc-id",
-                    "Values": [
-                        vpc_id
-                    ]
-                },
-            ]
-        )
-    except botocore.exceptions.ClientError as error:
-        logger.error("Unable to describe subnets")
-        raise error
-
-    if len(az_subnets.get("Subnets")) < 1:
-        logger.error("Unable to find subnets associated with AZ! Cannot replace route.")
-        raise MissingAZSubnetError(az_subnets)
-
-    public_subnet_id = ""
-    for subnet in az_subnets.get("Subnets"):
-        tags = subnet.get("Tags")
-        for tag in tags:
-            if tag.get("Key") == "Name":
-                subnet_name = tag.get("Value")
-                if f"public-{availability_zone}" in subnet_name:
-                    public_subnet_id = subnet.get("SubnetId")
-                    break
-
-    if public_subnet_id == "":
-        logger.error("Unable to find the public subnet ID for %s! Cannot replace route.", availability_zone)
-        raise MissingAZSubnetError(az_subnets)
-
-    logger.debug("Found subnet %s in VPC %s", public_subnet_id, vpc_id)
-    return vpc_id, public_subnet_id, lambda_subnet_id
+    return vpc_id
 
 
 def get_nat_gateway_id(vpc_id, subnet_id):
@@ -269,35 +92,21 @@ def get_nat_gateway_id(vpc_id, subnet_id):
     return nat_gateway_id
 
 
-def describe_and_replace_route(subnet_id, nat_gateway_id):
+def replace_route(route_table_id, nat_gateway_id):
+    new_route_table = {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": nat_gateway_id,
+        "RouteTableId": route_table_id
+    }
     try:
-        route_tables = ec2_client.describe_route_tables(
-            Filters=[{
-                "Name": "association.subnet-id",
-                "Values": [subnet_id]
-            }]
-        )
-    except botocore.exceptions.ClientError as error:
-        logger.error("Unable to describe route tables")
-        raise error
-
-    if len(route_tables.get("RouteTables")) < 1:
-        raise MissingRouteTableError(route_tables)
-
-    route_table = route_tables['RouteTables'][0]
-
-    new_route_table = {"DestinationCidrBlock": "0.0.0.0/0",
-                       "NatGatewayId": nat_gateway_id,
-                       "RouteTableId": route_table["RouteTableId"]}
-    try:
-        logger.info("Replacing existing route %s for route table %s", route_table, new_route_table)
+        logger.info("Replacing existing route %s for route table %s", route_table_id, new_route_table)
         ec2_client.replace_route(**new_route_table)
     except botocore.exceptions.ClientError as error:
         logger.error("Unable to replace route")
         raise error
 
 
-def check_connection(function_name, check_urls):
+def check_connection(check_urls):
     """
     Checks connectivity to check_urls. If any of them succeed, return success.
     If both fail, replaces the route table to point at a standby NAT Gateway and
@@ -314,45 +123,30 @@ def check_connection(function_name, check_urls):
 
     logger.warning("Failed connectivity tests! Replacing route")
 
-    vpc_id, public_subnet_id, lambda_subnet_id = get_vpc_and_subnets_from_lambda(function_name)
+    public_subnet_id = os.getenv("PUBLIC_SUBNET_ID")
+    if not public_subnet_id:
+        raise MissingEnvironmentVariableError("PUBLIC_SUBNET_ID")
+
+    route_tables = "ROUTE_TABLE_IDS_CSV" in os.environ and os.getenv("ROUTE_TABLE_IDS_CSV").split(",")
+    if not route_tables:
+        raise MissingEnvironmentVariableError("ROUTE_TABLE_IDS_CSV")
+    vpc_id = get_vpc_id(route_tables[0])
+
     nat_gateway_id = get_nat_gateway_id(vpc_id, public_subnet_id)
-    describe_and_replace_route(lambda_subnet_id, nat_gateway_id)
-    logger.info("Route replacement succeeded")
+
+    for rtb in route_tables:
+        replace_route(rtb, nat_gateway_id)
+        logger.info("Route replacement succeeded")
     return False
 
 
-def handler(event, _):
-    subnet_suffix = os.getenv("PRIVATE_SUBNET_SUFFIX", DEFAULT_SUBNET_SUFFIX)
-
-    try:
-        for record in event["Records"]:
-            message = json.loads(record["Sns"]["Message"])
-            if LIFECYCLE_KEY in message and ASG_KEY in message:
-                life_cycle_hook = message[LIFECYCLE_KEY]
-                auto_scaling_group = message[ASG_KEY]
-                instance_id = message[EC2_KEY]
-                logger.info("Handling Auto Scaling Group termination event for instance %s", instance_id)
-                logger.debug("Lifecycle Hook: %s", life_cycle_hook)
-                logger.debug("Auto Scaling Group: %s", auto_scaling_group)
-
-                availability_zone, vpc_zone_identifier = get_az_and_vpc_zone_identifier(auto_scaling_group)
-                vpc_id, private_subnet_id, public_subnet_id = get_vpc_and_subnet_id(subnet_suffix, availability_zone, vpc_zone_identifier)
-                nat_gateway_id = get_nat_gateway_id(vpc_id, public_subnet_id)
-                describe_and_replace_route(private_subnet_id, nat_gateway_id)
-
-                logger.info("Route replacement succeeded")
-                return
-
-        logger.error("Failed to find lifecyle message to parse")
-        raise LifecycleMessageError
-    except Exception as error:
-        logger.error("Error: %s", error)
-        raise error
-
-
 def connectivity_test_handler(event, context):
+    if not isinstance(event, dict):
+        logger.error(f"Unknown event: {event}")
+        return
+
     if event.get("source") != "aws.events":
-        logger.error("Unable to handle unknown event type: %s", json.dumps(event))
+        logger.error(f"Unable to handle unknown event type: {json.dumps(event)}")
         raise UnknownEventTypeError
 
     logger.info("Starting NAT instance connectivity test")
@@ -364,11 +158,40 @@ def connectivity_test_handler(event, context):
     run = 0
     num_runs = 60 / check_interval
     while run < num_runs:
-        if check_connection(context.function_name, check_urls):
+        if check_connection(check_urls):
             time.sleep(check_interval)
             run += 1
         else:
             break
+
+
+def handler(event, _):
+    try:
+        for record in event["Records"]:
+            message = json.loads(record["Sns"]["Message"])
+            if LIFECYCLE_KEY in message and ASG_KEY in message:
+                asg = message[ASG_KEY]
+            else:
+                logger.error("Failed to find lifecyle message to parse")
+                raise LifecycleMessageError
+    except Exception as error:
+        logger.error("Error: %s", error)
+        raise error
+
+    logger.warning("Failed connectivity tests! Replacing route")
+    availability_zone, vpc_zone_identifier = get_az_and_vpc_zone_identifier(asg)
+    public_subnet_id = vpc_zone_identifier.split(",")[0]
+    az = availability_zone.upper().replace("-", "_")
+    route_tables = az in os.environ and os.getenv(az).split(",")
+    if not route_tables:
+        raise MissingEnvironmentVariableError
+    vpc_id = get_vpc_id(route_tables[0])
+
+    nat_gateway_id = get_nat_gateway_id(vpc_id, public_subnet_id)
+
+    for rtb in route_tables:
+        replace_route(rtb, nat_gateway_id)
+        logger.info("Route replacement succeeded")
 
 
 class UnknownEventTypeError(Exception): pass
@@ -396,3 +219,6 @@ class MissingRouteTableError(Exception): pass
 
 
 class LifecycleMessageError(Exception): pass
+
+
+class MissingEnvironmentVariableError(Exception): pass

--- a/functions/replace-route/tests/test_replace_route.py
+++ b/functions/replace-route/tests/test_replace_route.py
@@ -7,6 +7,7 @@ import json
 import sys
 import zipfile
 import io
+import logging
 
 import boto3
 import sure
@@ -15,6 +16,11 @@ from requests import ConnectTimeout
 from moto import mock_autoscaling, mock_ec2, mock_iam, mock_lambda
 
 sys.path.append('..')
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+logging.getLogger('boto3').setLevel(logging.CRITICAL)
+logging.getLogger('botocore').setLevel(logging.CRITICAL)
 
 EXAMPLE_AMI_ID = "ami-12c6146b"
 
@@ -26,56 +32,66 @@ def setup_networking():
 
     vpc = ec2.create_vpc(CidrBlock="10.1.0.0/16")
 
-    subnet1 = ec2.create_subnet(
+    public_subnet = ec2.create_subnet(
         VpcId=vpc.id,
         CidrBlock="10.1.1.0/24",
         AvailabilityZone=f"{az}"
     )
-    subnet1.create_tags(Tags=[{
-        "Key": "Name",
-        "Value": f"public-{az}-mock"
-    }])
 
-    subnet2 = ec2.create_subnet(
+    private_subnet = ec2.create_subnet(
         VpcId=vpc.id,
         CidrBlock="10.1.2.0/24",
         AvailabilityZone=f"{az}",
     )
-    subnet2.create_tags(Tags=[{
-        "Key": "Name",
-        "Value": f"private-{az}-mock"
-    }])
+
+    private_subnet_two = ec2.create_subnet(
+        VpcId=vpc.id,
+        CidrBlock="10.1.3.0/24",
+        AvailabilityZone=f"{az}",
+    )
+
 
     route_table = ec2.create_route_table(VpcId=vpc.id)
+    route_table_two = ec2.create_route_table(VpcId=vpc.id)
     sg = ec2.create_security_group(GroupName="test-sg", Description="test-sg")
-
 
     ec2_client = boto3.client("ec2")
     allocation_id = ec2_client.allocate_address(Domain="vpc")["AllocationId"]
     nat_gw_id = ec2_client.create_nat_gateway(
-        SubnetId=subnet1.id,
+        SubnetId=public_subnet.id,
         AllocationId=allocation_id
     )["NatGateway"]["NatGatewayId"]
 
     eni = ec2_client.create_network_interface(
-        SubnetId=subnet1.id, PrivateIpAddress="10.1.1.5"
+        SubnetId=public_subnet.id, PrivateIpAddress="10.1.1.5"
     )
     ec2_client.associate_route_table(
         RouteTableId=route_table.id,
-        SubnetId=subnet2.id
+        SubnetId=private_subnet.id
     )
     ec2_client.create_route(
         DestinationCidrBlock="0.0.0.0/0",
         NetworkInterfaceId=eni["NetworkInterface"]["NetworkInterfaceId"],
         RouteTableId=route_table.id
     )
+    ec2_client.associate_route_table(
+        RouteTableId=route_table.id,
+        SubnetId=private_subnet_two.id
+    )
+    ec2_client.create_route(
+        DestinationCidrBlock="0.0.0.0/0",
+        NetworkInterfaceId=eni["NetworkInterface"]["NetworkInterfaceId"],
+        RouteTableId=route_table_two.id
+    )
 
     return {
         "vpc": vpc.id,
-        "subnet1": subnet1.id,
-        "subnet2": subnet2.id,
+        "public_subnet": public_subnet.id,
+        "private_subnet": private_subnet.id,
+        "private_subnet_two": private_subnet_two.id,
         "nat_gw": nat_gw_id,
         "route_table": route_table.id,
+        "route_table_two": route_table_two.id,
         "sg": sg.id,
     }
 
@@ -83,16 +99,18 @@ def setup_networking():
 def verify_nat_gateway_route(mocked_networking):
     ec2_client = boto3.client("ec2")
 
-    filters = [{"Name": "route-table-id", "Values": [mocked_networking["route_table"]]}]
+    filters = [{"Name": "route-table-id", "Values": [mocked_networking["route_table"],mocked_networking["route_table_two"]]}]
     route_tables = ec2_client.describe_route_tables(Filters=filters)["RouteTables"]
 
-    route_tables.should.have.length_of(1)
+    route_tables.should.have.length_of(2)
     route_tables[0]["Routes"].should.have.length_of(2)
+    route_tables[1]["Routes"].should.have.length_of(2)
 
-    for route in route_tables[0]["Routes"]:
-        if route["DestinationCidrBlock"] == "0.0.0.0/0":
-            zero_route = route
-    zero_route.should.have.key("NatGatewayId").equals(mocked_networking["nat_gw"])
+    for rt in route_tables:
+        for route in rt["Routes"]:
+            if route["DestinationCidrBlock"] == "0.0.0.0/0":
+                zero_route = route
+        zero_route.should.have.key("NatGatewayId").equals(mocked_networking["nat_gw"])
 
 
 @mock_autoscaling
@@ -108,7 +126,7 @@ def test_handler():
     autoscaling_client = boto3.client("autoscaling")
     autoscaling_client.create_auto_scaling_group(
         AutoScalingGroupName="alternat-asg",
-        VPCZoneIdentifier=mocked_networking["subnet1"],
+        VPCZoneIdentifier=mocked_networking["public_subnet"],
         MinSize=1,
         MaxSize=1,
         LaunchTemplate={
@@ -122,6 +140,9 @@ def test_handler():
     script_dir = os.path.dirname(__file__)
     with open(os.path.join(script_dir, "../sns-event.json"), "r") as file:
         asg_termination_event = file.read()
+
+    az = f"{os.environ['AWS_DEFAULT_REGION']}a".upper().replace("-", "_")
+    os.environ[az] = ",".join([mocked_networking["route_table"],mocked_networking["route_table_two"]])
 
     handler(json.loads(asg_termination_event), {})
 
@@ -160,20 +181,16 @@ def _process_lambda(func_str):
 @mock_ec2
 @responses.activate
 def test_connectivity_test_handler():
-    lambda_function_name = "alternat-connectivity-test"
+    from app import connectivity_test_handler
     mocked_networking = setup_networking()
 
     lambda_client = boto3.client("lambda")
+    lambda_function_name = "alternat-connectivity-test"
     lambda_client.create_function(
         FunctionName=lambda_function_name,
-        Runtime="python3.7",
         Role=get_role(),
-        Handler="lambda_function.lambda_handler",
         Code={"ZipFile": get_test_zip_file1()},
-        VpcConfig={"SecurityGroupIds": [mocked_networking["sg"]], "SubnetIds": [mocked_networking["subnet2"]]},
     )
-
-    from app import connectivity_test_handler
 
     script_dir = os.path.dirname(__file__)
     with open(os.path.join(script_dir, "../cloudwatch-event.json"), "r") as file:
@@ -184,6 +201,9 @@ def test_connectivity_test_handler():
 
     responses.add(responses.GET, 'https://www.example.com', body=ConnectTimeout())
     responses.add(responses.GET, 'https://www.google.com', body=ConnectTimeout())
+    os.environ["ROUTE_TABLE_IDS_CSV"] = ",".join([mocked_networking["route_table"], mocked_networking["route_table_two"]])
+    os.environ["PUBLIC_SUBNET_ID"] = mocked_networking["public_subnet"]
+
     connectivity_test_handler(event=json.loads(cloudwatch_event), context=Context())
 
     verify_nat_gateway_route(mocked_networking)

--- a/modules/terraform-aws-alternat/alternat.conf.tftpl
+++ b/modules/terraform-aws-alternat/alternat.conf.tftpl
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+USERDATA_CONFIG_FILE="/etc/alternat.conf"
+echo eip_allocation_ids_csv=${eip_allocation_ids_csv} >> "$USERDATA_CONFIG_FILE"
+echo route_table_ids_csv=${route_table_ids_csv} >> "$USERDATA_CONFIG_FILE"

--- a/modules/terraform-aws-alternat/lambda.tf
+++ b/modules/terraform-aws-alternat/lambda.tf
@@ -6,14 +6,20 @@ resource "aws_lambda_function" "alternat_autoscaling_hook" {
   image_uri     = "${var.alternat_image_uri}:${var.alternat_image_tag}"
   role          = aws_iam_role.nat_lambda_role.arn
   environment {
-    variables = {
-      PRIVATE_SUBNET_SUFFIX = var.subnet_suffix
-    }
+    variables = local.autoscaling_func_env_vars
   }
   tags = merge({
     FunctionName = "alternat-autoscaling-lifecycle-hook",
   }, var.tags)
   timeout = 300
+}
+
+locals {
+  autoscaling_func_env_vars = {
+    # Lambda function env vars cannot contain hyphens
+    for obj in var.vpc_az_maps
+    : replace(upper(obj.az), "-", "_") => join(",", obj.route_table_ids)
+  }
 }
 
 resource "aws_iam_role" "nat_lambda_role" {
@@ -50,22 +56,13 @@ data "aws_iam_policy_document" "alternat_lambda_permissions" {
   }
 
   statement {
-    sid    = "alterNATLambdaPermissions"
-    effect = "Allow"
-    actions = [
-      "lambda:GetFunction"
-    ]
-    resources = ["*"]
-  }
-
-  statement {
     sid    = "alterNATModifyRoutePermissions"
     effect = "Allow"
     actions = [
       "ec2:ReplaceRoute"
     ]
     resources = [
-      for route_table in var.private_route_table_ids
+      for route_table in local.all_route_tables
       : "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:route-table/${route_table}"
     ]
   }
@@ -104,9 +101,9 @@ resource "aws_sns_topic_subscription" "nat_lambda_topic_subscription" {
 
 # Lambda function for monitoring connectivity through the NAT instance
 resource "aws_lambda_function" "alternat_connectivity_tester" {
-  count = length(var.vpc_private_subnet_ids)
+  for_each = { for obj in var.vpc_az_maps : obj.az => obj }
 
-  function_name = "${var.connectivity_tester_function_name}-${count.index}"
+  function_name = "${var.connectivity_tester_function_name}-${each.key}"
   package_type  = "Image"
   memory_size   = 256
   timeout       = 300
@@ -120,17 +117,19 @@ resource "aws_lambda_function" "alternat_connectivity_tester" {
 
   environment {
     variables = {
-      CHECK_URLS = join(",", var.connectivity_test_check_urls)
+      ROUTE_TABLE_IDS_CSV = join(",", each.value.route_table_ids),
+      PUBLIC_SUBNET_ID    = each.value.public_subnet_id
+      CHECK_URLS          = join(",", var.connectivity_test_check_urls)
     }
   }
 
   vpc_config {
-    subnet_ids         = [var.vpc_private_subnet_ids[count.index]]
+    subnet_ids         = each.value.private_subnet_ids
     security_group_ids = [aws_security_group.nat_lambda.id]
   }
 
   tags = merge({
-    FunctionName = "alternat-connectivity-tester-${count.index}",
+    FunctionName = "alternat-connectivity-tester-${each.key}",
   }, var.tags)
 }
 
@@ -157,19 +156,19 @@ resource "aws_cloudwatch_event_rule" "every_minute" {
 }
 
 resource "aws_cloudwatch_event_target" "test_connection_every_minute" {
-  count = length(var.vpc_private_subnet_ids)
+  for_each = { for obj in var.vpc_az_maps : obj.az => obj }
 
   rule      = aws_cloudwatch_event_rule.every_minute.name
-  target_id = "connectivity-tester-${count.index}"
-  arn       = aws_lambda_function.alternat_connectivity_tester[count.index].arn
+  target_id = "connectivity-tester-${each.key}"
+  arn       = aws_lambda_function.alternat_connectivity_tester[each.key].arn
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_connectivity_tester" {
-  count = length(var.vpc_private_subnet_ids)
+  for_each = { for obj in var.vpc_az_maps : obj.az => obj }
 
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.alternat_connectivity_tester[count.index].function_name
+  function_name = aws_lambda_function.alternat_connectivity_tester[each.key].function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.every_minute.arn
 }

--- a/modules/terraform-aws-alternat/main.tf
+++ b/modules/terraform-aws-alternat/main.tf
@@ -4,7 +4,7 @@ locals {
     {
       name                    = "NATInstanceTerminationLifeCycleHook"
       default_result          = "CONTINUE"
-      heartbeat_timeout       = 180
+      heartbeat_timeout       = var.lifecycle_heartbeat_timeout
       lifecycle_transition    = "autoscaling:EC2_INSTANCE_TERMINATING"
       notification_target_arn = aws_sns_topic.alternat_topic.arn
       role_arn                = aws_iam_role.alternat_lifecycle_hook.arn
@@ -13,13 +13,20 @@ locals {
 
   nat_instance_ingress_sgs = concat(var.ingress_security_group_ids, [aws_security_group.nat_lambda.id])
 
+  all_private_subnets = flatten([
+    for obj in var.vpc_az_maps : obj.private_subnet_ids
+  ])
+  all_route_tables = flatten([
+    for obj in var.vpc_az_maps : obj.route_table_ids
+  ])
+
   ec2_endpoint = (
     var.enable_ec2_endpoint
     ? {
       ec2 = {
         service             = "ec2"
         private_dns_enabled = true
-        subnet_ids          = var.vpc_private_subnet_ids
+        subnet_ids          = local.all_private_subnets
         tags                = { Name = "ec2-vpc-endpoint" }
       }
     }
@@ -32,7 +39,7 @@ locals {
       lambda = {
         service             = "lambda"
         private_dns_enabled = true
-        subnet_ids          = var.vpc_private_subnet_ids
+        subnet_ids          = local.all_private_subnets
         tags                = { Name = "lambda-vpc-endpoint" }
       }
     }
@@ -41,12 +48,14 @@ locals {
 
   endpoints = merge(local.ec2_endpoint, local.lambda_endpoint)
 
-  reuse_nat_instance_eips = length(var.nat_instance_eip_ids) == length(var.vpc_public_subnet_ids) # var.nat_instance_eip_ids ignored if doesn't match subnet count
+  # Must provide exactly 1 EIP per AZ
+  # var.nat_instance_eip_ids ignored if doesn't match AZ count
+  reuse_nat_instance_eips = length(var.nat_instance_eip_ids) == length(var.vpc_az_maps)
   nat_instance_eip_ids    = local.reuse_nat_instance_eips ? var.nat_instance_eip_ids : aws_eip.nat_instance_eips[*].id
 }
 
 resource "aws_eip" "nat_instance_eips" {
-  count = local.reuse_nat_instance_eips ? 0 : length(var.vpc_public_subnet_ids)
+  count = local.reuse_nat_instance_eips ? 0 : length(var.vpc_az_maps)
 
   vpc = true
   tags = merge(var.tags, {
@@ -61,17 +70,16 @@ resource "aws_sns_topic" "alternat_topic" {
 }
 
 resource "aws_autoscaling_group" "nat_instance" {
-  count = length(var.vpc_public_subnet_ids)
+  for_each = { for obj in var.vpc_az_maps : obj.az => obj.public_subnet_id }
 
   name_prefix           = var.nat_instance_name_prefix
   max_size              = 1
   min_size              = 1
-  desired_capacity      = 1
   max_instance_lifetime = var.max_instance_lifetime
-  vpc_zone_identifier   = [var.vpc_public_subnet_ids[count.index]]
+  vpc_zone_identifier   = [each.value]
 
   launch_template {
-    id      = aws_launch_template.nat_instance_template.id
+    id      = aws_launch_template.nat_instance_template[each.key].id
     version = "$Latest"
   }
 
@@ -91,7 +99,7 @@ resource "aws_autoscaling_group" "nat_instance" {
   dynamic "tag" {
     for_each = merge(
       var.tags,
-      { Name = "${var.nat_instance_name_prefix}${count.index}" },
+      { Name = "${var.nat_instance_name_prefix}${each.key}" },
       data.aws_default_tags.current.tags,
     )
 
@@ -144,9 +152,6 @@ resource "aws_iam_role_policy" "alternat_lifecycle_hook" {
 }
 
 
-data "aws_region" "current" {}
-data "aws_caller_identity" "current" {}
-
 data "aws_ami" "amazon_linux_2" {
   most_recent = true
   owners      = ["amazon"]
@@ -167,7 +172,27 @@ data "aws_ami" "amazon_linux_2" {
   }
 }
 
+data "template_cloudinit_config" "config" {
+  for_each = { for obj in var.vpc_az_maps : obj.az => obj.route_table_ids }
+
+  gzip          = true
+  base64_encode = true
+  part {
+    content_type = "text/x-shellscript"
+    content = templatefile("${path.module}/alternat.conf.tftpl", {
+      eip_allocation_ids_csv = join(",", local.nat_instance_eip_ids),
+      route_table_ids_csv    = join(",", each.value)
+    })
+  }
+  part {
+    content_type = "text/x-shellscript"
+    content      = file("${path.module}/../../scripts/alternat.sh")
+  }
+}
+
 resource "aws_launch_template" "nat_instance_template" {
+  for_each = { for obj in var.vpc_az_maps : obj.az => obj.route_table_ids }
+
   block_device_mappings {
     device_name = "/dev/sda1"
 
@@ -211,11 +236,7 @@ resource "aws_launch_template" "nat_instance_template" {
     })
   }
 
-  user_data = base64encode(templatefile("${path.module}/alternat.sh.tftpl", {
-    tf_eip_allocation_ids = join(",", local.nat_instance_eip_ids),
-    tf_subnet_suffix      = var.subnet_suffix,
-    tf_vpc_id             = var.vpc_id
-  }))
+  user_data = data.template_cloudinit_config.config[each.key].rendered
 }
 
 resource "aws_security_group" "nat_instance" {
@@ -319,7 +340,7 @@ data "aws_iam_policy_document" "alternat_ec2_policy" {
       "ec2:ReplaceRoute"
     ]
     resources = [
-      for route_table in var.private_route_table_ids
+      for route_table in local.all_route_tables
       : "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:route-table/${route_table}"
     ]
   }
@@ -353,19 +374,19 @@ resource "aws_iam_role_policy" "alternat_additional_policies" {
 
 ## NAT Gateway used as a backup route
 resource "aws_eip" "nat_gateway_eips" {
-  count = length(var.vpc_public_subnet_ids)
-  vpc   = true
+  for_each = { for obj in var.vpc_az_maps : obj.az => obj.public_subnet_id }
+  vpc      = true
   tags = merge(var.tags, {
-    "Name" = "alternat-gateway-${count.index}"
+    "Name" = "alternat-gateway-eip"
   })
 }
 
 resource "aws_nat_gateway" "main" {
-  count         = length(var.vpc_public_subnet_ids)
-  allocation_id = aws_eip.nat_gateway_eips[count.index].id
-  subnet_id     = var.vpc_public_subnet_ids[count.index]
+  for_each      = { for obj in var.vpc_az_maps : obj.az => obj.public_subnet_id }
+  allocation_id = aws_eip.nat_gateway_eips[each.key].id
+  subnet_id     = each.value
   tags = merge(var.tags, {
-    Name = "alternat-${count.index}"
+    Name = "alternat-${each.key}"
   })
 }
 
@@ -411,3 +432,5 @@ module "vpc_endpoints" {
 }
 
 data "aws_default_tags" "current" {}
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}

--- a/modules/terraform-aws-alternat/outputs.tf
+++ b/modules/terraform-aws-alternat/outputs.tf
@@ -1,9 +1,9 @@
 output "nat_instance_eips" {
-  description = "List of Elastic IP addresses used by the NAT instances."
-  value       = aws_eip.nat_instance_eips[*].public_ip
+  description = "List of Elastic IP addresses used by the NAT instances. This will be empty if EIPs are provided in var.nat_instance_eip_ids."
+  value       = local.reuse_nat_instance_eips ? [] : aws_eip.nat_instance_eips[*].public_ip
 }
 
 output "nat_gateway_eips" {
   description = "List of Elastic IP addresses used by the standby NAT gateways."
-  value       = aws_eip.nat_gateway_eips[*].public_ip
+  value       = [for eip in aws_eip.nat_gateway_eips : eip.public_ip]
 }

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -7,6 +7,17 @@ variable "additional_instance_policies" {
   default = []
 }
 
+variable "alternat_image_tag" {
+  description = "The tag of the container image for the HA NAT Lambda functions."
+  type        = string
+  default     = "latest"
+}
+
+variable "alternat_image_uri" {
+  description = "The URI of the container image for the HA NAT Lambda functions."
+  type        = string
+}
+
 variable "architecture" {
   description = "Architecture of the NAT instance image. Must be compatible with nat_instance_type."
   type        = string
@@ -55,21 +66,16 @@ variable "enable_ssm" {
   default     = true
 }
 
-variable "alternat_image_tag" {
-  description = "The tag of the container image for the HA NAT Lambda functions."
-  type        = string
-  default     = "latest"
-}
-
-variable "alternat_image_uri" {
-  description = "The URI of the container image for the HA NAT Lambda functions."
-  type        = string
-}
-
 variable "ingress_security_group_ids" {
   description = "A list of security group IDs that are allowed by the NAT instance."
   type        = list(string)
   default     = []
+}
+
+variable "lifecycle_heartbeat_timeout" {
+  description = "The length of time, in seconds, that autoscaled NAT instances should wait in the terminate state before being fully terminated."
+  type        = number
+  default     = 180
 }
 
 variable "max_instance_lifetime" {
@@ -136,34 +142,23 @@ variable "nat_instance_eip_ids" {
   default     = []
 }
 
-variable "private_route_table_ids" {
-  description = "A list of private route tables that the NAT instances will manage."
-  type        = list(string)
-}
-
-variable "subnet_suffix" {
-  description = "Suffix in the NAT private subnet name to search for when updating routes via HA NAT Lambda functions."
-  type        = string
-  default     = "private"
-}
-
 variable "tags" {
   description = "A map of tags to add to all supported resources managed by the module."
   type        = map(string)
   default     = {}
 }
 
+variable "vpc_az_maps" {
+  description = "A map of az to private route tables that the NAT instances will manage."
+  type = list(object({
+    az                 = string
+    private_subnet_ids = list(string)
+    public_subnet_id   = string
+    route_table_ids    = list(string)
+  }))
+}
+
 variable "vpc_id" {
   description = "The ID of the VPC."
   type        = string
-}
-
-variable "vpc_private_subnet_ids" {
-  description = "A list of private subnets IDs inside the VPC."
-  type        = list(any)
-}
-
-variable "vpc_public_subnet_ids" {
-  description = "A list of public subnets IDs inside the VPC."
-  type        = list(any)
 }

--- a/scripts/alternat.sh
+++ b/scripts/alternat.sh
@@ -27,7 +27,7 @@ validate_var() {
    var_name="$1"
    var_val="$2"
    if [ ! "$2" ]; then
-      echo "Config var "$var_name" is unset"
+      echo "Config var \"$var_name\" is unset"
       exit 1
    fi
 }


### PR DESCRIPTION
This update includes a few important changes:

- Modifies the userdata and Lambda function inputs for compatibility with other IaC tooling such as CDK that cannot use Terraform template style.
- Allows multiple sets of private subnets/route tables. Previously it was only possible to include one set of private route tables and subnets within a VPC.
- Exposes the Auto Scaling Group Lifecycle hook heartbeat timeout value.
- Eliminates the dependency on a particular naming convention for private subnets. Subnets are now passed explicitly, so we don't need to discover them by name.

This release requires migration steps to avoid downtime. I've added a new `docs/` directory with the migration guide.
