### PR TITLE
feature: native lambda deployment

### DIFF
--- a/modules/terraform-aws-alternat/lambda.tf
+++ b/modules/terraform-aws-alternat/lambda.tf
@@ -146,7 +146,7 @@ resource "aws_lambda_function" "alternat_connectivity_tester" {
   source_code_hash = var.lambda_package_type == "Zip" ? base64sha256(filebase64(var.lambda_zip_path)) : null
 
   dynamic "image_config" {
-    for_each = var.lambda_package_type == "Image" ? [var.lambda_image_config] : []
+    for_each = var.lambda_package_type == "Image" ? [var.lambda_image_config.connectivity_tester] : []
 
     content {
       command = image_config.value.command

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -121,7 +121,7 @@ variable "nat_instance_sg_name_prefix" {
 }
 
 variable "nat_lambda_function_role_name" {
-  description = "Name ot use for the IAM role used by the replace-route Lambda function. Must be globally unique in this AWS account."
+  description = "Name to use for the IAM role used by the replace-route Lambda function. Must be globally unique in this AWS account."
   type        = string
   default     = ""
 }
@@ -161,4 +161,50 @@ variable "vpc_az_maps" {
 variable "vpc_id" {
   description = "The ID of the VPC."
   type        = string
+}
+
+variable "lambda_package_type" {
+  description = "The lambda deployment package type. Valid values are \"Zip\" and \"Image\". Defaults to \"Image\"."
+  type        = string
+  default     = "Image"
+  nullable    = false
+}
+
+variable "lambda_memory_size" {
+  description = "Amount of memory in MB your Lambda Function can use at runtime. Defaults to 256."
+  type        = number
+  default     = 256
+}
+
+variable "lambda_timeout" {
+  description = "Amount of time your Lambda Function has to run in seconds. Defaults to 300."
+  type        = number
+  default     = 300
+}
+variable "lambda_handler" {
+  description = "The name of the handler to use for the lambda function. Required when `lambda_package_type` is \"Zip\"."
+  type        = string
+  default     = "app.handler"
+}
+
+variable "lambda_image_config" {
+  description = "Container image configuration values that override the values in the container image Dockerfile."
+  type = object({
+    command : optional(list(string)),
+  })
+  default = {
+    command : ["app.connectivity_test_handler"],
+  }
+  nullable = false
+}
+
+variable "lambda_environment_variables" {
+  description = "Environment variables to be provided to the lambda function."
+  type        = map(string)
+  default     = null
+}
+variable "lambda_zip_path" {
+  description = "The location where the generated zip file should be stored. Required when `lambda_package_type` is \"Zip\"."
+  type        = string
+  default     = "/tmp/alternat-lambda.zip"
 }

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -168,6 +168,11 @@ variable "lambda_package_type" {
   type        = string
   default     = "Image"
   nullable    = false
+
+  validation {
+    condition     = contains(["Zip", "Image"], var.lambda_package_type)
+    error_message = "Must be a supported package type: \"Zip\" or \"Image\"."
+  }
 }
 
 variable "lambda_memory_size" {
@@ -199,6 +204,7 @@ variable "lambda_environment_variables" {
   type        = map(string)
   default     = null
 }
+
 variable "lambda_zip_path" {
   description = "The location where the generated zip file should be stored. Required when `lambda_package_type` is \"Zip\"."
   type        = string

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -190,10 +190,20 @@ variable "lambda_handler" {
 variable "lambda_image_config" {
   description = "Container image configuration values that override the values in the container image Dockerfile."
   type = object({
-    command : optional(list(string)),
+    connectivity_tester : {
+      command : optional(list(string)),
+    }
+    alternat_autoscaling_hook : {
+      command : optional(list(string)),
+    }
   })
   default = {
-    command : ["app.connectivity_test_handler"],
+    connectivity_tester : {
+      command : ["app.connectivity_test_handler"],
+    }
+    alternat_autoscaling_hook : {
+      command : ["app.handler"],
+    }
   }
   nullable = false
 }

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -181,31 +181,17 @@ variable "lambda_timeout" {
   type        = number
   default     = 300
 }
-variable "lambda_handler" {
-  description = "The name of the handler to use for the lambda function. Required when `lambda_package_type` is \"Zip\"."
-  type        = string
-  default     = "app.handler"
-}
 
-variable "lambda_image_config" {
-  description = "Container image configuration values that override the values in the container image Dockerfile."
+variable "lambda_handlers" {
+  description = "Lambda handlers."
   type = object({
-    connectivity_tester : {
-      command : optional(list(string)),
-    }
-    alternat_autoscaling_hook : {
-      command : optional(list(string)),
-    }
+    connectivity_tester       = string,
+    alternat_autoscaling_hook = string,
   })
   default = {
-    connectivity_tester : {
-      command : ["app.connectivity_test_handler"],
-    }
-    alternat_autoscaling_hook : {
-      command : ["app.handler"],
-    }
+    connectivity_tester       = "app.connectivity_test_handler",
+    alternat_autoscaling_hook = "app.handler"
   }
-  nullable = false
 }
 
 variable "lambda_environment_variables" {


### PR DESCRIPTION
This PRs: 
- adds `lambda_package_type` (defaults to `Image`) variable to control what runtime is used for executing Lambda: `Image` or `Zip`,
- moves some of the hardcoded values into variables.