### PR TITLE
feature: Adds support for optionally creating NAT Gateways

### DIFF
--- a/modules/terraform-aws-alternat/main.tf
+++ b/modules/terraform-aws-alternat/main.tf
@@ -371,15 +371,23 @@ resource "aws_iam_role_policy" "alternat_additional_policies" {
 
 ## NAT Gateway used as a backup route
 resource "aws_eip" "nat_gateway_eips" {
-  for_each = { for obj in var.vpc_az_maps : obj.az => obj.public_subnet_id }
-  vpc      = true
+  for_each = {
+    for obj in var.vpc_az_maps
+    : obj.az => obj.public_subnet_id
+    if var.create_nat_gateways
+  }
+  vpc = true
   tags = merge(var.tags, {
     "Name" = "alternat-gateway-eip"
   })
 }
 
 resource "aws_nat_gateway" "main" {
-  for_each      = { for obj in var.vpc_az_maps : obj.az => obj.public_subnet_id }
+  for_each = {
+    for obj in var.vpc_az_maps
+    : obj.az => obj.public_subnet_id
+    if var.create_nat_gateways
+  }
   allocation_id = aws_eip.nat_gateway_eips[each.key].id
   subnet_id     = each.value
   tags = merge(var.tags, {

--- a/modules/terraform-aws-alternat/outputs.tf
+++ b/modules/terraform-aws-alternat/outputs.tf
@@ -5,5 +5,9 @@ output "nat_instance_eips" {
 
 output "nat_gateway_eips" {
   description = "List of Elastic IP addresses used by the standby NAT gateways."
-  value       = [for eip in aws_eip.nat_gateway_eips : eip.public_ip]
+  value = [
+    for eip in aws_eip.nat_gateway_eips
+    : eip.public_ip
+    if var.create_nat_gateways
+  ]
 }

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -30,6 +30,12 @@ variable "autoscaling_hook_function_name" {
   default     = "alternat-autoscaling-hook"
 }
 
+variable "create_nat_gateways" {
+  description = "Whether to create the NAT Gateway and the NAT Gateway EIP in this module. If false, you must create and manage NAT Gateways separately."
+  type        = bool
+  default     = true
+}
+
 variable "connectivity_test_check_urls" {
   description = "List of URLs to check with the connectivity tester function."
   type        = list(string)


### PR DESCRIPTION
Fixes #47

Allows the user to set `create_nat_gateways=false`. The user can manage NAT gateways separately - within the vpc module, for example - and alterNAT will work with those rather than provision its own.
