### PR TITLE
Drop the `requests` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ As described above, alterNAT uses the [`ReplaceRoute` API](https://docs.aws.amaz
 
 ## Usage and Considerations
 
-There are two ways how you can deploy alterNAT with Terraform module from this repository:
+There are two ways to deploy alterNAT:
 
 - By building a Docker image and using AWS Lambda support for containers
 - By using AWS Lambda runtime for Python directly

--- a/functions/replace-route/app.py
+++ b/functions/replace-route/app.py
@@ -27,6 +27,7 @@ DEFAULT_CONNECTIVITY_CHECK_INTERVAL = "5"
 # Which URLs to check for connectivity
 DEFAULT_CHECK_URLS = ["https://www.example.com", "https://www.google.com"]
 
+
 REQUEST_TIMEOUT = 5
 
 def get_az_and_vpc_zone_identifier(auto_scaling_group):

--- a/functions/replace-route/app.py
+++ b/functions/replace-route/app.py
@@ -2,11 +2,11 @@ import os
 import json
 import logging
 import time
+import urllib
+import socket
 
 import botocore
 import boto3
-import requests
-from requests import ReadTimeout, ConnectTimeout, HTTPError, Timeout, ConnectionError, RequestException
 
 
 logger = logging.getLogger()
@@ -114,12 +114,13 @@ def check_connection(check_urls):
     """
     for url in check_urls:
         try:
-            requests.get(url, timeout=REQUEST_TIMEOUT)
+            urllib.request.urlopen(url, timeout=REQUEST_TIMEOUT)
             logger.debug("Successfully connected to %s", url)
             return True
-        except (ReadTimeout, ConnectTimeout, HTTPError, Timeout,
-                ConnectionError, RequestException) as error:
+        except (urllib.error.URLError, urllib.error.HTTPError) as error:
             logger.error("error connecting to %s: %s", url, error)
+        except socket.timeout as error:
+            logger.error("timeout error connecting to %s: %s", url, error)
 
     logger.warning("Failed connectivity tests! Replacing route")
 

--- a/functions/replace-route/requirements.txt
+++ b/functions/replace-route/requirements.txt
@@ -1,8 +1,1 @@
 boto3==1.24.62
-botocore==1.27.62
-jmespath==1.0.1
-python-dateutil==2.8.2
-s3transfer==0.6.0
-six==1.16.0
-urllib3==1.26.12
-requests==2.28.1

--- a/functions/replace-route/tests/test_requirements.txt
+++ b/functions/replace-route/tests/test_requirements.txt
@@ -1,4 +1,3 @@
 moto[ec2,autoscaling,iam,awslambda]==4.0.6
 pytest==7.1.3
 sure==2.0.0
-responses==0.21.0

--- a/modules/terraform-aws-alternat/lambda.tf
+++ b/modules/terraform-aws-alternat/lambda.tf
@@ -1,22 +1,9 @@
-resource "null_resource" "prepare_artifact" {
-  count = var.lambda_package_type == "Zip" ? 1 : 0
-
-  triggers = {
-    dependencies_versions = filemd5("${path.module}/../../functions/replace-route/requirements.txt")
-  }
-
-  provisioner "local-exec" {
-    command = "pip install -r ${path.module}/../../functions/replace-route/requirements.txt -t ${path.module}/../../functions/replace-route"
-  }
-}
-
 data "archive_file" "lambda" {
   count       = var.lambda_package_type == "Zip" ? 1 : 0
   type        = "zip"
   source_dir  = "${path.module}/../../functions/replace-route"
   excludes    = ["__pycache__"]
   output_path = var.lambda_zip_path
-  depends_on  = [null_resource.prepare_artifact]
 }
 
 # Lambda function for Auto Scaling Group Lifecycle Hook

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -16,6 +16,7 @@ variable "alternat_image_tag" {
 variable "alternat_image_uri" {
   description = "The URI of the container image for the HA NAT Lambda functions."
   type        = string
+  default     = ""
 }
 
 variable "architecture" {


### PR DESCRIPTION
This PR:
- drops the dependency for `requests` library in favour of builtin `urllib` (Thanks @jgr-trackunit!)
- updates readme to mention both deployment options for Terraform
- makes `alternat_image_uri` Terraform variable optional

The rationale behind the removal is that alterNAT can now be deployed using builtin AWS Lambda Python runtime which by default has all the required third-party dependencies preinstalled (`boto3`). 

This removes the necessity to:
- build the image locally
- run `pip install -r ...` inside Terraform via `local-exec` provisioner, which proved to be error-prone in shared environments (CI/CD, Atlantis, etc.)

Tested, can confirm working.

Closes: https://github.com/1debit/alternat/issues/45