### PR TITLE
Root EBS - /dev/xvda for Arm images

### DIFF
--- a/modules/terraform-aws-alternat/main.tf
+++ b/modules/terraform-aws-alternat/main.tf
@@ -191,7 +191,7 @@ resource "aws_launch_template" "nat_instance_template" {
   for_each = { for obj in var.vpc_az_maps : obj.az => obj.route_table_ids }
 
   block_device_mappings {
-    device_name = "/dev/sda1"
+    device_name = "/dev/xvda"
 
     ebs {
       volume_size = 80


### PR DESCRIPTION
### Issue

When I am using `ARM` images alternat provisions another EBS as `/dev/sda1` and root EBS is still 8GB unencrypted. I assume this is not intentional and there should be only one root EBS with encryption enabled:

<img width="1638" alt="image" src="https://user-images.githubusercontent.com/903531/221575915-948db6e6-90bc-4786-b96a-5319646b7191.png">




### Fix
I've changed the configured block device mapping to `/dev/xvda` which is root volume for `ARM` images https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html?icmpid=docs_ec2_console#device-name-limits

```
aws ec2 describe-images --image-ids ami-0cd7323ab3e63805f --region us-east-1
{
    "Images": [
        {
            "Architecture": "arm64",
            "CreationDate": "2023-02-09T11:53:44.000Z",
            "ImageId": "ami-0cd7323ab3e63805f",
            "ImageLocation": "amazon/amzn2-ami-kernel-5.10-hvm-2.0.20230207.0-arm64-gp2",
            "ImageType": "machine",
            "Public": true,
            "OwnerId": "137112412989",
            "PlatformDetails": "Linux/UNIX",
            "UsageOperation": "RunInstances",
            "State": "available",
            "BlockDeviceMappings": [
                {
                    "DeviceName": "/dev/xvda",
                    "Ebs": {
                        "DeleteOnTermination": true,
                        "SnapshotId": "snap-04cb0f411fe7a3137",
                        "VolumeSize": 8,
                        "VolumeType": "gp2",
                        "Encrypted": false
                    }
                }
            ],
            "Description": "Amazon Linux 2 LTS Arm64 Kernel 5.10 AMI 2.0.20230207.0 arm64 HVM gp2",
            "EnaSupport": true,
            "Hypervisor": "xen",
            "ImageOwnerAlias": "amazon",
            "Name": "amzn2-ami-kernel-5.10-hvm-2.0.20230207.0-arm64-gp2",
            "RootDeviceName": "/dev/xvda",
            "RootDeviceType": "ebs",
            "SriovNetSupport": "simple",
            "VirtualizationType": "hvm",
            "DeprecationTime": "2025-02-09T11:53:44.000Z"
        }
    ]
}

```

After the fix:

<img width="1619" alt="image" src="https://user-images.githubusercontent.com/903531/221576680-f6959fc9-00b9-409f-aaa7-f98e4b2f3817.png">
