### PR TITLE
Adds optional EBS volume customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ module "alternat_instances" {
 
   lambda_package_type = "Image"
 
+  # Optional EBS volume settings. If omitted, the AMI defaults will be used.
+  nat_instance_block_devices = {
+    xvda = {
+      device_name = "/dev/xvda"
+      ebs = {
+        encrypted   = true
+        volume_type = "gp3"
+        volume_size = 20
+      }
+    }
+  }
+
   tags = var.tags
 
   vpc_id      = module.vpc.vpc_id

--- a/modules/terraform-aws-alternat/main.tf
+++ b/modules/terraform-aws-alternat/main.tf
@@ -191,7 +191,7 @@ resource "aws_launch_template" "nat_instance_template" {
   for_each = { for obj in var.vpc_az_maps : obj.az => obj.route_table_ids }
 
   block_device_mappings {
-    device_name = "/dev/sda1"
+    device_name = "/dev/xvda"
 
     ebs {
       volume_size = 80

--- a/modules/terraform-aws-alternat/main.tf
+++ b/modules/terraform-aws-alternat/main.tf
@@ -190,12 +190,21 @@ data "cloudinit_config" "config" {
 resource "aws_launch_template" "nat_instance_template" {
   for_each = { for obj in var.vpc_az_maps : obj.az => obj.route_table_ids }
 
-  block_device_mappings {
-    device_name = "/dev/xvda"
+  dynamic "block_device_mappings" {
+    for_each = try(var.nat_instance_block_devices, {})
 
-    ebs {
-      volume_size = 80
-      encrypted   = true
+    content {
+      device_name = try(block_device_mappings.value.device_name, null)
+
+      dynamic "ebs" {
+        for_each = try([block_device_mappings.value.ebs], [])
+
+        content {
+          encrypted   = try(ebs.value.encrypted, null)
+          volume_size = try(ebs.value.volume_size, null)
+          volume_type = try(ebs.value.volume_type, null)
+        }
+      }
     }
   }
 

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -97,6 +97,12 @@ variable "nat_ami" {
   default     = ""
 }
 
+variable "nat_instance_block_devices" {
+  description = "Optional custom EBS volume settings for the NAT instance."
+  type        = any
+  default     = {}
+}
+
 variable "nat_instance_iam_profile_name" {
   description = "Name to use for the IAM profile used by the NAT instance. Must be globally unique in this AWS account. Defaults to alternat-instance- as a prefix."
   type        = string


### PR DESCRIPTION
Allows the user to optionally add custom block devices to the NAT instance. Removes the unnecessary and unused additional 80GB volume.

Alternative to #56.