### PR TITLE
Output NAT Instance Security Group

### DIFF
--- a/modules/terraform-aws-alternat/outputs.tf
+++ b/modules/terraform-aws-alternat/outputs.tf
@@ -11,3 +11,8 @@ output "nat_gateway_eips" {
     if var.create_nat_gateways
   ]
 }
+
+output "nat_instance_security_group_id" {
+  description = "NAT Instance Security Group ID."
+  value = aws_security_group.nat_instance.id
+}


### PR DESCRIPTION
This will allow users to use the `aws_security_group_rule` resource to attach additional security group rules to the NAT Instance Security Group.

For example:
```yaml
module "alternat_instances" {
  # ...
}

resource "aws_security_group_rule" "alternat_ingress_shared_vpc" {
  type              = "ingress"
  protocol          = "-1"
  from_port         = 0
  to_port           = 0
  cidr_blocks       = ["10.0.0.0/8"] # <== my entire internal VPC CIDR range
  security_group_id = module.alternat_instances.nat_instance_security_group_id
}
```