### PR TITLE
Remove deprecated vpc argument to aws_eip

### DIFF
--- a/modules/terraform-aws-alternat/main.tf
+++ b/modules/terraform-aws-alternat/main.tf
@@ -54,7 +54,6 @@ locals {
 resource "aws_eip" "nat_instance_eips" {
   count = local.reuse_nat_instance_eips ? 0 : length(var.vpc_az_maps)
 
-  domain = "vpc"
   tags = merge(var.tags, {
     "Name" = "alternat-instance-${count.index}"
   })
@@ -394,7 +393,6 @@ resource "aws_eip" "nat_gateway_eips" {
     : obj.az => obj.public_subnet_id
     if var.create_nat_gateways
   }
-  domain = "vpc"
   tags = merge(var.tags, {
     "Name" = "alternat-gateway-eip"
   })

--- a/modules/terraform-aws-alternat/main.tf
+++ b/modules/terraform-aws-alternat/main.tf
@@ -54,7 +54,7 @@ locals {
 resource "aws_eip" "nat_instance_eips" {
   count = local.reuse_nat_instance_eips ? 0 : length(var.vpc_az_maps)
 
-  vpc = true
+  domain = "vpc"
   tags = merge(var.tags, {
     "Name" = "alternat-instance-${count.index}"
   })
@@ -394,7 +394,7 @@ resource "aws_eip" "nat_gateway_eips" {
     : obj.az => obj.public_subnet_id
     if var.create_nat_gateways
   }
-  vpc = true
+  domain = "vpc"
   tags = merge(var.tags, {
     "Name" = "alternat-gateway-eip"
   })


### PR DESCRIPTION
The `vpc = true` is throwing deprecation diagnostics. It still works this way, but is not referenced in the [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) anymore.

<img width="1064" alt="Screenshot 2023-09-28 at 7 49 50 AM" src="https://github.com/1debit/alternat/assets/97087/4388d0f2-0749-4d8c-a16a-10fb3156f23a">

Ran a `terraform plan` against my forked version and the plan came up clean (no changes) without any of the warning diagnostics.