### PR TITLE
Declare versions for provider

### DIFF
--- a/modules/terraform-aws-alternat/versions.tf
+++ b/modules/terraform-aws-alternat/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.20"
+    }
+  }
+}

--- a/modules/terraform-aws-alternat/versions.tf
+++ b/modules/terraform-aws-alternat/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.20"
+      version = ">= 4"
     }
   }
 }


### PR DESCRIPTION
Declare versions to prevent the following error if you want to set a provider for regions using alterNAT. Using the default versions for the current [terraform-aws-vpc module](https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/versions.tf)

```terraform
module "test" {
  source    = "git::https://github.com/1debit/alternat.git//modules/terraform-aws-alternat?ref=v0.4.6"
  providers = { aws = aws.us-east-1 }
  ....
```

```
There is no explicit declaration for local provider name "aws" in module.test, so Terraform is assuming you mean to pass a
configuration for "hashicorp/aws".
```
