### PR TITLE
Add pre-install user data

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,15 @@ While we'd like for this to be available on the Terraform Registry, it requires 
 
 - There are four Elastic IP addresses for the NAT instances and four for the NAT Gateways. Be sure to add all eight addresses to any external allow lists if necessary.
 
+- If you plan on running this in a dual stack network (IPv4 and IPv6), you may notice that it takes ~10 minutes for an alternat node to start. In that case, you can use the `nat_instance_user_data_pre_install` variable to prefer IPv4 over IPv6 before running any user data.
+
+  ```tf
+    nat_instance_user_data_pre_install = <<-EOF
+      # Prefer IPv4 over IPv6
+      echo 'precedence ::ffff:0:0/96 100' >> /etc/gai.conf
+    EOF
+  ```
+
 ## Future work
 
 We would like this benefit to benefit as many users as possible. Possible future enhancements include:

--- a/modules/terraform-aws-alternat/main.tf
+++ b/modules/terraform-aws-alternat/main.tf
@@ -302,6 +302,17 @@ resource "aws_security_group_rule" "nat_instance_ip_range_ingress" {
   cidr_blocks       = var.ingress_security_group_cidr_blocks
 }
 
+resource "aws_security_group_rule" "nat_instance_ipv6_range_ingress" {
+  count = length(var.ingress_security_group_ipv6_cidr_blocks) > 0 ? 1 : 0
+
+  type              = "ingress"
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  security_group_id = aws_security_group.nat_instance.id
+  ipv6_cidr_blocks  = var.ingress_security_group_ipv6_cidr_blocks
+}
+
 ### NAT instance IAM
 
 resource "aws_iam_instance_profile" "nat_instance" {

--- a/modules/terraform-aws-alternat/main.tf
+++ b/modules/terraform-aws-alternat/main.tf
@@ -173,6 +173,16 @@ data "cloudinit_config" "config" {
 
   gzip          = true
   base64_encode = true
+
+  dynamic "part" {
+    for_each = var.nat_instance_user_data_pre_install != "" ? [1] : []
+
+    content {
+      content_type = "text/x-shellscript"
+      content      = var.nat_instance_user_data_pre_install
+    }
+  }
+
   part {
     content_type = "text/x-shellscript"
     content = templatefile("${path.module}/alternat.conf.tftpl", {
@@ -180,6 +190,7 @@ data "cloudinit_config" "config" {
       route_table_ids_csv    = join(",", each.value)
     })
   }
+
   part {
     content_type = "text/x-shellscript"
     content      = file("${path.module}/../../scripts/alternat.sh")
@@ -282,13 +293,13 @@ resource "aws_security_group_rule" "nat_instance_ingress" {
 
 resource "aws_security_group_rule" "nat_instance_ip_range_ingress" {
   count = length(var.ingress_security_group_cidr_blocks) > 0 ? 1 : 0
-  
-  type                     = "ingress"
-  protocol                 = "-1"
-  from_port                = 0
-  to_port                  = 0
-  security_group_id        = aws_security_group.nat_instance.id
-  cidr_blocks = var.ingress_security_group_cidr_blocks
+
+  type              = "ingress"
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  security_group_id = aws_security_group.nat_instance.id
+  cidr_blocks       = var.ingress_security_group_cidr_blocks
 }
 
 ### NAT instance IAM

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -161,6 +161,12 @@ variable "nat_instance_eip_ids" {
   default     = []
 }
 
+variable "nat_instance_user_data_pre_install" {
+  description = "Pre-install shell script to run at boot before configuring alternat."
+  type        = string
+  default     = ""
+}
+
 variable "nat_instance_user_data_post_install" {
   description = "Post-install shell script to run at boot after configuring alternat."
   type        = string
@@ -247,4 +253,3 @@ variable "lambda_layer_arns" {
   description = "List of Lambda layers ARN that will be added to functions"
   default     = null
 }
-

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -1,6 +1,6 @@
 variable "additional_instance_policies" {
   description = "Additional policies for the HA NAT instance IAM role."
-  type        = list(object({
+  type = list(object({
     policy_name = string
     policy_json = string
   }))
@@ -81,6 +81,12 @@ variable "ingress_security_group_ids" {
 
 variable "ingress_security_group_cidr_blocks" {
   description = "A list of CIDR blocks that are allowed by the NAT instance."
+  type        = list(string)
+  default     = []
+}
+
+variable "ingress_security_group_ipv6_cidr_blocks" {
+  description = "A list of IPv6 CIDR blocks that are allowed by the NAT instance."
   type        = list(string)
   default     = []
 }
@@ -181,7 +187,7 @@ variable "tags" {
 
 variable "vpc_az_maps" {
   description = "A map of az to private route tables that the NAT instances will manage."
-  type        = list(object({
+  type = list(object({
     az                 = string
     private_subnet_ids = list(string)
     public_subnet_id   = string
@@ -220,7 +226,7 @@ variable "lambda_timeout" {
 
 variable "lambda_handlers" {
   description = "Lambda handlers."
-  type        = object({
+  type = object({
     connectivity_tester       = string,
     alternat_autoscaling_hook = string,
   })


### PR DESCRIPTION
I've been looking at adding NAT64 support to this and have been successful using the `nat_instance_user_data_post_install` variable. However, I noticed that when an instance is running in a dual stack network, DNS resolution is extremely slow (or possibly just API calls in general). For example, it takes 15m to provision an alternat instance + my post install script. I discovered it was the awscli calls that took forever.

I found a way to increase the precedence of IPv4 addresses on the host using the getaddrinfo config. To test it, I wanted to make sure it was the first thing that happened in the user data, so I added a `nat_instance_user_data_pre_install` variable and set it to this:

```sh
nat_instance_user_data_pre_install = <<-EOF
  # Prefer IPv4 over IPv6
  echo 'precedence ::ffff:0:0/96 100' >> /etc/gai.conf
EOF
```

My instance setup time in a dual stack network went from ~15m to 2m.

Since I don't want to make any assumptions about people's networks (route table and subnet configurations) or whether they're using Jool vs Tayga (NAT64), I don't think it would make sense to add any of that stuff to this project, but a pre-install user data variable might?