### PR TITLE
New option to disable IPv6 in the connectivity test

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ While we'd like for this to be available on the Terraform Registry, it requires 
       echo 'precedence ::ffff:0:0/96 100' >> /etc/gai.conf
     EOF
   ```
-- If you see errors like: `error connecting to https://www.google.com/: <urlopen error [Errno 97] Address family not supported by protocol>` in the connectivity tester logs, you can set `lambda_has_ipv6 = false`. This will cause the lambda to request IPv4 addresses only in DNS looikups.
+- If you see errors like: `error connecting to https://www.google.com/: <urlopen error [Errno 97] Address family not supported by protocol>` in the connectivity tester logs, you can set `lambda_has_ipv6 = false`. This will cause the lambda to request IPv4 addresses only in DNS lookups.
 
 
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ While we'd like for this to be available on the Terraform Registry, it requires 
       echo 'precedence ::ffff:0:0/96 100' >> /etc/gai.conf
     EOF
   ```
+- If you see errors like: `error connecting to https://www.google.com/: <urlopen error [Errno 97] Address family not supported by protocol>` in the connectivity tester logs, you can set `lambda_has_ipv6 = false`. This will cause the lambda to request IPv4 addresses only in DNS looikups.
+
+
 
 ## Future work
 

--- a/functions/replace-route/tests/test_replace_route.py
+++ b/functions/replace-route/tests/test_replace_route.py
@@ -206,3 +206,16 @@ def test_connectivity_test_handler(mock_urlopen):
     connectivity_test_handler(event=json.loads(cloudwatch_event), context=Context())
 
     verify_nat_gateway_route(mocked_networking)
+
+
+def test_disable_ipv6():
+    results = socket.getaddrinfo("google.com", 80)
+    families = [family for family, _, _, _, _ in results]
+    assert socket.AF_INET6 in families, "Unable to find a non-IPv4 address family in getaddrinfo results before patching getaddrinfo"
+
+    from app import disable_ipv6
+    disable_ipv6()
+    results = socket.getaddrinfo("google.com", 80)
+    for family, _, _, _, _ in results:
+        assert family == socket.AF_INET, "Found a non-IPv4 address family in getaddrinfo results"
+

--- a/modules/terraform-aws-alternat/lambda.tf
+++ b/modules/terraform-aws-alternat/lambda.tf
@@ -27,7 +27,6 @@ resource "aws_lambda_function" "alternat_autoscaling_hook" {
   environment {
     variables = merge(
       local.autoscaling_func_env_vars,
-      local.has_ipv6_env_var,
       var.lambda_environment_variables,
     )
   }
@@ -152,11 +151,15 @@ resource "aws_lambda_function" "alternat_connectivity_tester" {
   }
 
   environment {
-    variables = merge({
-      ROUTE_TABLE_IDS_CSV = join(",", each.value.route_table_ids),
-      PUBLIC_SUBNET_ID    = each.value.public_subnet_id
-      CHECK_URLS          = join(",", var.connectivity_test_check_urls)
-    }, var.lambda_environment_variables)
+    variables = merge(
+      {
+        ROUTE_TABLE_IDS_CSV = join(",", each.value.route_table_ids),
+        PUBLIC_SUBNET_ID    = each.value.public_subnet_id
+        CHECK_URLS          = join(",", var.connectivity_test_check_urls)
+      },
+      local.has_ipv6_env_var,
+      var.lambda_environment_variables,
+    )
   }
 
   vpc_config {

--- a/modules/terraform-aws-alternat/lambda.tf
+++ b/modules/terraform-aws-alternat/lambda.tf
@@ -1,3 +1,12 @@
+locals {
+  autoscaling_func_env_vars = {
+    # Lambda function env vars cannot contain hyphens
+    for obj in var.vpc_az_maps
+    : replace(upper(obj.az), "-", "_") => join(",", obj.route_table_ids)
+  }
+  has_ipv6_env_var = { "HAS_IPV6" = var.lambda_has_ipv6 }
+}
+
 data "archive_file" "lambda" {
   count       = var.lambda_package_type == "Zip" ? 1 : 0
   type        = "zip"
@@ -34,15 +43,6 @@ resource "aws_lambda_function" "alternat_autoscaling_hook" {
   tags = merge({
     FunctionName = "alternat-autoscaling-lifecycle-hook",
   }, var.tags)
-}
-
-locals {
-  autoscaling_func_env_vars = {
-    # Lambda function env vars cannot contain hyphens
-    for obj in var.vpc_az_maps
-    : replace(upper(obj.az), "-", "_") => join(",", obj.route_table_ids)
-  }
-  has_ipv6_env_var = { "HAS_IPV6" = var.lambda_has_ipv6 }
 }
 
 resource "aws_iam_role" "nat_lambda_role" {

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -242,6 +242,12 @@ variable "lambda_environment_variables" {
   default     = null
 }
 
+variable "lambda_has_ipv6" {
+  description = "Controls whether or not the lambda function can use IPv6."
+  type        = bool
+  default     = true
+}
+
 variable "lambda_zip_path" {
   description = "The location where the generated zip file should be stored. Required when `lambda_package_type` is \"Zip\"."
   type        = string


### PR DESCRIPTION
Fixes #87.

This PR adds a new boolean variable to the Terraform module, `lambda_has_ipv6` (true by default). If set to `false`, the connectivity test in the Lambda function will always resolve IPv4 addresses.