### PR TITLE
Allow overriding NAT Gateway for fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,13 @@ While we'd like for this to be available on the Terraform Registry, it requires 
   ```
 - If you see errors like: `error connecting to https://www.google.com/: <urlopen error [Errno 97] Address family not supported by protocol>` in the connectivity tester logs, you can set `lambda_has_ipv6 = false`. This will cause the lambda to request IPv4 addresses only in DNS lookups.
 
+- If you want to use just a single NAT Gateway for fallback, you can create it externally and provide its ID through the `nat_gateway_id` variable. Note that you will incur cross AZ traffic charges of $0.01/GB.
+
+  ```tf
+    create_nat_gateways = false
+    nat_gateway_id      = "nat-..."
+  ```
+
 
 
 ## Future work

--- a/functions/replace-route/app.py
+++ b/functions/replace-route/app.py
@@ -82,6 +82,11 @@ def get_vpc_id(route_table):
 
 
 def get_nat_gateway_id(vpc_id, subnet_id):
+    nat_gateway_id = os.getenv("NAT_GATEWAY_ID")
+    if nat_gateway_id:
+        logger.info("Using NAT_GATEWAY_ID env. variable (%s)", nat_gateway_id)
+        return nat_gateway_id
+
     try:
         nat_gateways = ec2_client.describe_nat_gateways(
             Filters=[

--- a/modules/terraform-aws-alternat/lambda.tf
+++ b/modules/terraform-aws-alternat/lambda.tf
@@ -36,6 +36,7 @@ resource "aws_lambda_function" "alternat_autoscaling_hook" {
   environment {
     variables = merge(
       local.autoscaling_func_env_vars,
+      { NAT_GATEWAY_ID = var.nat_gateway_id },
       var.lambda_environment_variables,
     )
   }
@@ -156,6 +157,7 @@ resource "aws_lambda_function" "alternat_connectivity_tester" {
         ROUTE_TABLE_IDS_CSV = join(",", each.value.route_table_ids),
         PUBLIC_SUBNET_ID    = each.value.public_subnet_id
         CHECK_URLS          = join(",", var.connectivity_test_check_urls)
+        NAT_GATEWAY_ID      = var.nat_gateway_id,
       },
       local.has_ipv6_env_var,
       var.lambda_environment_variables,

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -195,6 +195,12 @@ variable "vpc_az_maps" {
   }))
 }
 
+variable "nat_gateway_id" {
+  description = "NAT Gateway ID to use for fallback. If not provided, the gateway in the same subnet as relevant NAT instance is selected."
+  type        = string
+  default     = ""
+}
+
 variable "vpc_id" {
   description = "The ID of the VPC."
   type        = string


### PR DESCRIPTION
Hello, thanks a lot for this wonderful module! I'd like to propose a simple extension that may be useful for some users.

It may be the case that only NAT Gateway is kept for fallback from alternat instances, since paying for separate gateways per AZ may not be worth the extra `NatGatewayHours` costs.

In such case, it can be useful to manage the single NAT Gateway outside of the module, and provide its ID to Lambda functions. This would override the default behaviour of selecting the NAT Gateway in the same subnet for fallback.
```hcl
resource "aws_nat_gateway" "this" {}

module "alternat" {
  create_nat_gateways = false
  lambda_environment_variables = {
    NAT_GATEWAY_ID = aws_nat_gateway.this.id
  }
}
```